### PR TITLE
Disable WDT for CPU1 idle task

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -69,6 +69,9 @@ void app_main(void)
 
     // Task Watchdog is auto-initialized by Kconfig (CONFIG_ESP_TASK_WDT_INIT=y)
     // Just register tasks that need monitoring (e.g., in gui_task)
+    // Remove idle task on core 1 from WDT so GUI task can fully utilize CPU1
+    // without triggering the watchdog due to the idle task not running.
+    esp_task_wdt_delete(xTaskGetIdleTaskHandleForCPU(1));
 
     Wireless_Init();
     Driver_Init();


### PR DESCRIPTION
## Summary
- prevent task watchdog resets by removing CPU1 idle task from monitoring

## Testing
- `pio run` *(fails: command not found)*
- `pip install platformio` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68bf458d064c8330b7a08b102c434c74