### PR TITLE
Handle set_temp and pressure MQTT states

### DIFF
--- a/src/Wireless/Wireless.c
+++ b/src/Wireless/Wireless.c
@@ -255,6 +255,8 @@ uint16_t BLE_Scan(void)
 static esp_mqtt_client_handle_t s_mqtt = NULL;
 static TimerHandle_t s_mqtt_update_timer = NULL;
 static float s_current_temp = 0.0f;
+static float s_set_temp = 0.0f;
+static float s_pressure = 0.0f;
 static const char *s_mqtt_topics[] = {
     "brew_setpoint",
     "steam_setpoint",
@@ -321,6 +323,10 @@ static void mqtt_event_handler(void *handler_args, esp_event_base_t base, int32_
             printf("MQTT state [%s] = %s\r\n", t_copy, d_copy);
             if (strstr(t_copy, "current_temp")) {
                 s_current_temp = strtof(d_copy, NULL);
+            } else if (strstr(t_copy, "set_temp")) {
+                s_set_temp = strtof(d_copy, NULL);
+            } else if (strstr(t_copy, "pressure")) {
+                s_pressure = strtof(d_copy, NULL);
             }
         }
         break;
@@ -377,6 +383,16 @@ void MQTT_Start(void)
 float MQTT_GetCurrentTemp(void)
 {
     return s_current_temp;
+}
+
+float MQTT_GetSetTemp(void)
+{
+    return s_set_temp;
+}
+
+float MQTT_GetPressure(void)
+{
+    return s_pressure;
 }
 
 esp_mqtt_client_handle_t MQTT_GetClient(void)

--- a/src/Wireless/Wireless.h
+++ b/src/Wireless/Wireless.h
@@ -32,3 +32,5 @@ void MQTT_Start(void);
 esp_mqtt_client_handle_t MQTT_GetClient(void);
 int MQTT_Publish(const char *topic, const char *payload, int qos, bool retain);
 float MQTT_GetCurrentTemp(void);
+float MQTT_GetSetTemp(void);
+float MQTT_GetPressure(void);


### PR DESCRIPTION
## Summary
- Track MQTT set_temp and pressure states and parse incoming values
- Expose new getters for set temperature and pressure readings

## Testing
- `pio run` *(fails: command not found)*
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf5d87cc888330aa3cf341da2daa7c