### PR TITLE
Avoid unused parameter warning

### DIFF
--- a/src/LVGL_UI/LVGL_Example.c
+++ b/src/LVGL_UI/LVGL_Example.c
@@ -408,6 +408,7 @@ void example1_increase_lvgl_tick(lv_timer_t * t)
 
 static void ta_event_cb(lv_event_t * e)
 {
+  LV_UNUSED(e);
 }
 
 


### PR DESCRIPTION
## Summary
- Mark `ta_event_cb` event parameter as unused to clean up compiler warnings

## Testing
- `pio run` *(fails: command not found)*
- `pip install platformio` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bfeeb0ce948330a35ba62c5b1711f9