### PR TITLE
Fix arc visibility for temp meter

### DIFF
--- a/src/LVGL_UI/LVGL_Example.c
+++ b/src/LVGL_UI/LVGL_Example.c
@@ -301,14 +301,16 @@ static void Status_create(lv_obj_t * parent)
   lv_obj_center(temp_meter);
   lv_obj_set_y(temp_meter, tab_h_global / 2);
   lv_obj_set_style_pad_all(temp_meter, 0, 0);
-  lv_obj_set_style_bg_opa(temp_meter, LV_OPA_TRANSP, 0);
+  lv_obj_set_style_bg_color(temp_meter, lv_palette_main(LV_PALETTE_YELLOW), 0);
+  lv_obj_set_style_bg_opa(temp_meter, LV_OPA_COVER, 0);
   lv_obj_set_style_border_width(temp_meter, 0, 0);
 
   lv_meter_scale_t * scale = lv_meter_add_scale(temp_meter);
   lv_meter_set_scale_ticks(temp_meter, scale, 11, 2, 10, lv_palette_main(LV_PALETTE_GREY));
   lv_meter_set_scale_range(temp_meter, scale, 60, 160, 270, 135);
-  current_temp_indic = lv_meter_add_arc(temp_meter, scale, 10, lv_palette_main(LV_PALETTE_RED), 0);
+  current_temp_indic = lv_meter_add_arc(temp_meter, scale, 10, lv_palette_main(LV_PALETTE_YELLOW), 0);
   lv_meter_set_indicator_start_value(temp_meter, current_temp_indic, 60);
+  lv_meter_set_indicator_end_value(temp_meter, current_temp_indic, 60);
   set_temp_indic = lv_meter_add_scale_lines(temp_meter, scale,
                                             lv_palette_main(LV_PALETTE_BLUE),
                                             lv_palette_main(LV_PALETTE_BLUE),


### PR DESCRIPTION
## Summary
- ensure temp meter has opaque yellow background
- draw yellow arc and initialize with default value

## Testing
- `pio run` *(fails: command not found)*
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bffbedd54483309d629716945ad513