### PR TITLE
Fix arc visibility and range handling

### DIFF
--- a/src/LVGL_UI/LVGL_Example.c
+++ b/src/LVGL_UI/LVGL_Example.c
@@ -3,8 +3,7 @@
 /**********************
  *      TYPEDEFS
  **********************/
-typedef enum
-{
+typedef enum {
   DISP_SMALL,
   DISP_MEDIUM,
   DISP_LARGE,
@@ -46,8 +45,7 @@ static lv_obj_t *current_temp_arc;
 static lv_obj_t *set_temp_arc;
 lv_obj_t *Backlight_slider;
 
-void Lvgl_Example1(void)
-{
+void Lvgl_Example1(void) {
 
   if (LV_HOR_RES <= 320)
     disp_size = DISP_SMALL;
@@ -59,8 +57,7 @@ void Lvgl_Example1(void)
   font_normal = LV_FONT_DEFAULT;
 
   lv_coord_t tab_h;
-  if (disp_size == DISP_LARGE)
-  {
+  if (disp_size == DISP_LARGE) {
     tab_h = 70;
 #if LV_FONT_MONTSERRAT_24
     font_large = &lv_font_montserrat_24;
@@ -74,9 +71,7 @@ void Lvgl_Example1(void)
     LV_LOG_WARN("LV_FONT_MONTSERRAT_16 is not enabled for the widgets demo. "
                 "Using LV_FONT_DEFAULT instead.");
 #endif
-  }
-  else if (disp_size == DISP_MEDIUM)
-  {
+  } else if (disp_size == DISP_MEDIUM) {
     tab_h = 45;
 #if LV_FONT_MONTSERRAT_20
     font_large = &lv_font_montserrat_20;
@@ -90,9 +85,7 @@ void Lvgl_Example1(void)
     LV_LOG_WARN("LV_FONT_MONTSERRAT_14 is not enabled for the widgets demo. "
                 "Using LV_FONT_DEFAULT instead.");
 #endif
-  }
-  else
-  { /* disp_size == DISP_SMALL */
+  } else { /* disp_size == DISP_SMALL */
     tab_h = 45;
 #if LV_FONT_MONTSERRAT_18
     font_large = &lv_font_montserrat_18;
@@ -146,8 +139,7 @@ void Lvgl_Example1(void)
 
   lv_obj_set_style_text_font(lv_scr_act(), font_normal, 0);
 
-  if (disp_size == DISP_LARGE)
-  {
+  if (disp_size == DISP_LARGE) {
     /* Large displays do not require additional header content. */
   }
 
@@ -167,17 +159,13 @@ void Lvgl_Example1(void)
   // color_changer_create(tv);
 }
 
-static void led_event_cb(lv_event_t *e)
-{
+static void led_event_cb(lv_event_t *e) {
   lv_obj_t *led = (lv_obj_t *)lv_event_get_user_data(e);
   lv_obj_t *sw = lv_event_get_target(e);
-  if (lv_obj_get_state(sw) & LV_STATE_CHECKED)
-  {
+  if (lv_obj_get_state(sw) & LV_STATE_CHECKED) {
     lv_led_on(led);
     Buzzer_On();
-  }
-  else
-  {
+  } else {
     lv_led_off(led);
     Buzzer_Off();
   }
@@ -185,15 +173,13 @@ static void led_event_cb(lv_event_t *e)
 
 static void back_event_cb(lv_event_t *e) { lv_scr_load(main_screen); }
 
-static void open_settings_event_cb(lv_event_t *e)
-{
+static void open_settings_event_cb(lv_event_t *e) {
   if (!settings_scr)
     Settings_create();
   lv_scr_load(settings_scr);
 }
 
-static void Settings_create(void)
-{
+static void Settings_create(void) {
   settings_scr = lv_obj_create(NULL);
   lv_obj_set_style_bg_color(settings_scr, lv_color_hex(0x000000), 0);
   lv_obj_set_style_bg_opa(settings_scr, LV_OPA_COVER, 0);
@@ -211,8 +197,8 @@ static void Settings_create(void)
   static lv_coord_t grid_main_col_dsc[] = {LV_GRID_FR(1), LV_GRID_FR(1),
                                            LV_GRID_TEMPLATE_LAST};
   static lv_coord_t grid_main_row_dsc[] = {
-      LV_GRID_CONTENT, LV_GRID_CONTENT, LV_GRID_CONTENT, LV_GRID_CONTENT,
-      LV_GRID_FR(1), LV_GRID_CONTENT, LV_GRID_TEMPLATE_LAST};
+      LV_GRID_CONTENT, LV_GRID_CONTENT, LV_GRID_CONTENT,      LV_GRID_CONTENT,
+      LV_GRID_FR(1),   LV_GRID_CONTENT, LV_GRID_TEMPLATE_LAST};
   lv_obj_set_grid_dsc_array(t, grid_main_col_dsc, grid_main_row_dsc);
 
   lv_obj_t *back_btn = lv_btn_create(t);
@@ -284,8 +270,7 @@ static void Settings_create(void)
 //   lv_obj_align(sw, LV_ALIGN_CENTER, 60, 0);
 //   lv_obj_add_event_cb(sw, led_event_cb, LV_EVENT_VALUE_CHANGED, led);
 // }
-void Lvgl_Example1_close(void)
-{
+void Lvgl_Example1_close(void) {
   /*Delete all animation*/
   lv_anim_del(NULL, NULL);
 
@@ -307,8 +292,7 @@ void Lvgl_Example1_close(void)
  *   STATIC FUNCTIONS
  **********************/
 
-static void Status_create(lv_obj_t *parent)
-{
+static void Status_create(lv_obj_t *parent) {
   static lv_coord_t grid_main_col_dsc[] = {LV_GRID_FR(1),
                                            LV_GRID_TEMPLATE_LAST};
   static lv_coord_t grid_main_row_dsc[] = {LV_GRID_FR(1), LV_GRID_CONTENT,
@@ -318,12 +302,13 @@ static void Status_create(lv_obj_t *parent)
   lv_obj_set_style_bg_opa(parent, LV_OPA_COVER, 0);
   lv_obj_set_style_border_width(parent, 0, 0);
 
-  lv_coord_t meter_size = lv_obj_get_content_width(parent) + tab_h_global;
+  lv_coord_t meter_size = LV_MIN(lv_obj_get_content_width(parent),
+                                 lv_obj_get_content_height(parent)) -
+                          20;
 
   set_temp_arc = lv_arc_create(parent);
   lv_obj_set_size(set_temp_arc, meter_size, meter_size);
   lv_obj_center(set_temp_arc);
-  lv_obj_set_y(set_temp_arc, tab_h_global / 2);
   lv_arc_set_range(set_temp_arc, 60, 160);
   lv_arc_set_rotation(set_temp_arc, 135);
   lv_arc_set_bg_angles(set_temp_arc, 0, 270);
@@ -331,19 +316,17 @@ static void Status_create(lv_obj_t *parent)
   lv_obj_clear_flag(set_temp_arc, LV_OBJ_FLAG_CLICKABLE);
   lv_obj_set_style_arc_width(set_temp_arc, 2, LV_PART_MAIN);
   lv_obj_set_style_arc_width(set_temp_arc, 2, LV_PART_INDICATOR);
-  lv_obj_set_style_arc_color(set_temp_arc,
-                             lv_palette_darken(LV_PALETTE_GREY, 2),
-                             LV_PART_MAIN);
+  lv_obj_set_style_arc_color(
+      set_temp_arc, lv_palette_darken(LV_PALETTE_GREY, 2), LV_PART_MAIN);
   lv_obj_set_style_arc_color(set_temp_arc, lv_palette_main(LV_PALETTE_BLUE),
                              LV_PART_INDICATOR);
   lv_obj_set_style_bg_opa(set_temp_arc, LV_OPA_TRANSP, 0);
   lv_obj_set_style_border_width(set_temp_arc, 0, 0);
-  lv_arc_set_value(set_temp_arc, 60);
+  lv_arc_set_value(set_temp_arc, 80);
 
   current_temp_arc = lv_arc_create(parent);
   lv_obj_set_size(current_temp_arc, meter_size, meter_size);
   lv_obj_center(current_temp_arc);
-  lv_obj_set_y(current_temp_arc, tab_h_global / 2);
   lv_arc_set_range(current_temp_arc, 60, 160);
   lv_arc_set_rotation(current_temp_arc, 135);
   lv_arc_set_bg_angles(current_temp_arc, 0, 270);
@@ -351,16 +334,13 @@ static void Status_create(lv_obj_t *parent)
   lv_obj_clear_flag(current_temp_arc, LV_OBJ_FLAG_CLICKABLE);
   lv_obj_set_style_arc_width(current_temp_arc, 10, LV_PART_MAIN);
   lv_obj_set_style_arc_width(current_temp_arc, 10, LV_PART_INDICATOR);
-  lv_obj_set_style_arc_color(current_temp_arc,
-                             lv_palette_darken(LV_PALETTE_GREY, 2),
-                             LV_PART_MAIN);
-  lv_obj_set_style_arc_color(current_temp_arc,
-                             lv_palette_main(LV_PALETTE_YELLOW),
-                             LV_PART_INDICATOR);
+  lv_obj_set_style_arc_color(
+      current_temp_arc, lv_palette_darken(LV_PALETTE_GREY, 2), LV_PART_MAIN);
+  lv_obj_set_style_arc_color(
+      current_temp_arc, lv_palette_main(LV_PALETTE_YELLOW), LV_PART_INDICATOR);
   lv_obj_set_style_bg_opa(current_temp_arc, LV_OPA_TRANSP, 0);
   lv_obj_set_style_border_width(current_temp_arc, 0, 0);
-  lv_arc_set_value(current_temp_arc, 60);
-  lv_obj_move_foreground(current_temp_arc);
+  lv_arc_set_value(current_temp_arc, 80);
 
   lv_obj_t *overlay = lv_obj_create(parent);
   lv_obj_set_size(overlay, LV_PCT(100), LV_PCT(100));
@@ -368,6 +348,9 @@ static void Status_create(lv_obj_t *parent)
   lv_obj_set_style_border_width(overlay, 0, 0);
   lv_obj_clear_flag(overlay, LV_OBJ_FLAG_SCROLLABLE);
   lv_obj_set_grid_dsc_array(overlay, grid_main_col_dsc, grid_main_row_dsc);
+
+  lv_obj_move_foreground(set_temp_arc);
+  lv_obj_move_foreground(current_temp_arc);
 
   lv_obj_t *status_area = lv_obj_create(overlay);
   lv_obj_set_style_bg_opa(status_area, LV_OPA_TRANSP, 0);
@@ -390,29 +373,29 @@ static void Status_create(lv_obj_t *parent)
   auto_step_timer = lv_timer_create(example1_increase_lvgl_tick, 100, NULL);
 }
 
-void example1_increase_lvgl_tick(lv_timer_t *t)
-{
+void example1_increase_lvgl_tick(lv_timer_t *t) {
   float current = MQTT_GetCurrentTemp();
   float set = MQTT_GetSetTemp();
-  if (current_temp_arc)
-    lv_arc_set_value(current_temp_arc, (int32_t)current);
-  if (set_temp_arc)
-    lv_arc_set_value(set_temp_arc, (int32_t)set);
+  if (current_temp_arc) {
+    int32_t current_val = LV_MIN(LV_MAX((int32_t)current, 60), 160);
+    lv_arc_set_value(current_temp_arc, current_val);
+  }
+  if (set_temp_arc) {
+    int32_t set_val = LV_MIN(LV_MAX((int32_t)set, 60), 160);
+    lv_arc_set_value(set_temp_arc, set_val);
+  }
   if (Backlight_slider)
     lv_slider_set_value(Backlight_slider, LCD_Backlight, LV_ANIM_ON);
   LVGL_Backlight_adjustment(LCD_Backlight);
 }
 
-void Backlight_adjustment_event_cb(lv_event_t *e)
-{
+void Backlight_adjustment_event_cb(lv_event_t *e) {
   uint8_t Backlight = lv_slider_get_value(lv_event_get_target(e));
-  if (Backlight <= Backlight_MAX)
-  {
+  if (Backlight <= Backlight_MAX) {
     lv_slider_set_value(Backlight_slider, Backlight, LV_ANIM_ON);
     LCD_Backlight = Backlight;
     LVGL_Backlight_adjustment(Backlight);
-  }
-  else
+  } else
     printf("Volume out of range: %d\n", Backlight);
 }
 


### PR DESCRIPTION
## Summary
- prevent LVGL arcs from being clipped by sizing to available space and centering them
- keep temperature arcs above the overlay and initialize with a visible value
- clamp MQTT temperature values to arc range to avoid disappearing indicators

## Testing
- ⚠️ `pio run` *(failed: command not found)*
- ⚠️ `pip install --user platformio` *(failed: Could not find a version that satisfies the requirement platformio)*

------
https://chatgpt.com/codex/tasks/task_e_68c010174f9c83308b6487f4d958bbff