### PR TITLE
Add mirrored pressure arc

### DIFF
--- a/src/LVGL_UI/LVGL_Example.h
+++ b/src/LVGL_UI/LVGL_Example.h
@@ -16,6 +16,12 @@
 #define TEMP_ARC_MAX 160
 #define TEMP_ARC_TICK 10
 
+#define PRESSURE_ARC_START 300
+#define PRESSURE_ARC_SIZE 120
+#define PRESSURE_ARC_MIN 0
+#define PRESSURE_ARC_MAX 10
+#define PRESSURE_ARC_TICK 1
+
 void Backlight_adjustment_event_cb(lv_event_t *e);
 
 void Lvgl_Example1(void);

--- a/src/Wireless/Wireless.c
+++ b/src/Wireless/Wireless.c
@@ -83,6 +83,8 @@ static esp_mqtt_client_handle_t s_mqtt = NULL;
 static TimerHandle_t s_mqtt_update_timer = NULL;
 static float s_current_temp = 0.0f;
 static float s_set_temp = 0.0f;
+static float s_current_pressure = 0.0f;
+static float s_set_pressure = 0.0f;
 static const char *s_mqtt_topics[] = {
     "brew_setpoint",
     "steam_setpoint",
@@ -92,6 +94,8 @@ static const char *s_mqtt_topics[] = {
     "current_temp",
     "shot",
     "steam",
+    "current_pressure",
+    "set_pressure",
 };
 
 static void mqtt_subscribe_all(bool log)
@@ -163,6 +167,14 @@ static void mqtt_event_handler(void *handler_args, esp_event_base_t base, int32_
             {
                 s_set_temp = strtof(d_copy, NULL);
             }
+            else if (strstr(t_copy, "current_pressure"))
+            {
+                s_current_pressure = strtof(d_copy, NULL);
+            }
+            else if (strstr(t_copy, "set_pressure"))
+            {
+                s_set_pressure = strtof(d_copy, NULL);
+            }
         }
         break;
     default:
@@ -227,6 +239,16 @@ float MQTT_GetCurrentTemp(void)
 float MQTT_GetSetTemp(void)
 {
     return s_set_temp;
+}
+
+float MQTT_GetCurrentPressure(void)
+{
+    return s_current_pressure;
+}
+
+float MQTT_GetSetPressure(void)
+{
+    return s_set_pressure;
 }
 
 esp_mqtt_client_handle_t MQTT_GetClient(void)

--- a/src/Wireless/Wireless.h
+++ b/src/Wireless/Wireless.h
@@ -18,3 +18,5 @@ esp_mqtt_client_handle_t MQTT_GetClient(void);
 int MQTT_Publish(const char *topic, const char *payload, int qos, bool retain);
 float MQTT_GetCurrentTemp(void);
 float MQTT_GetSetTemp(void);
+float MQTT_GetCurrentPressure(void);
+float MQTT_GetSetPressure(void);


### PR DESCRIPTION
## Summary
- add pressure arc constants and mirrored arc rendering alongside existing temperature arc
- support tick and value updates for new pressure arc
- extend MQTT interface to handle pressure topics and expose getters

## Testing
- `pio run` *(fails: command not found)*
- `pip install platformio` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c02656e9288330aa354e5ef40e1842