### PR TITLE
Use PRId32 for int32_t formatting

### DIFF
--- a/src/LVGL_UI/LVGL_Example.c
+++ b/src/LVGL_UI/LVGL_Example.c
@@ -1,6 +1,7 @@
 #include "LVGL_Example.h"
 #include <math.h>
 #include <stdio.h>
+#include <inttypes.h>
 
 /**********************
  *      TYPEDEFS
@@ -499,7 +500,7 @@ static void set_label_value(lv_obj_t *label, float value, const char *suffix)
   char buf[16];
   int32_t whole = (int32_t)value;
   int32_t frac = (int32_t)(fabsf(value) * 10.0f + 0.5f) % 10;
-  snprintf(buf, sizeof(buf), "%d.%d%s", whole, frac, suffix);
+  snprintf(buf, sizeof(buf), "%" PRId32 ".%" PRId32 "%s", whole, frac, suffix);
   lv_label_set_text(label, buf);
 }
 


### PR DESCRIPTION
## Summary
- include `<inttypes.h>` to support standard integer macros
- format int32_t values with `PRId32` in `set_label_value`

## Testing
- ❌ `pio run -e esp32-s3-devkitc-1` *(platformio not installed; attempted installation failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c02f872a808330bd3a18c4c2c89046