### PR TITLE
Fix settings button overlay issue

### DIFF
--- a/src/LVGL_UI/LVGL_Example.c
+++ b/src/LVGL_UI/LVGL_Example.c
@@ -395,6 +395,8 @@ static void Status_create(lv_obj_t *parent)
   lv_obj_center(settings_label);
   lv_obj_add_event_cb(settings_btn, open_settings_event_cb, LV_EVENT_CLICKED,
                       NULL);
+  /* Ensure the settings button is above overlay layers like tick_layer */
+  lv_obj_move_foreground(settings_btn);
 
   auto_step_timer = lv_timer_create(example1_increase_lvgl_tick, 100, NULL);
 }


### PR DESCRIPTION
## Summary
- Ensure settings button is moved above overlay layers to remain clickable

## Testing
- `idf.py --version` *(fails: command not found)*
- `cmake -S . -B build` *(fails: include could not find requested file: /tools/cmake/project.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68c0427a47308330b18a101cac859da2