### PR TITLE
Add fallback LVGL symbol definitions

### DIFF
--- a/src/LVGL_UI/LVGL_Example.c
+++ b/src/LVGL_UI/LVGL_Example.c
@@ -3,6 +3,21 @@
 #include <math.h>
 #include <stdio.h>
 
+/* Fallback symbol definitions for environments where newer LVGL symbols are
+ * not provided. These values correspond to Font Awesome code points and allow
+ * the project to compile even with older LVGL releases. */
+#ifndef LV_SYMBOL_TEMPERATURE
+#define LV_SYMBOL_TEMPERATURE "\xEF\x8B\x89"
+#endif
+
+#ifndef LV_SYMBOL_SPEED
+#define LV_SYMBOL_SPEED "\xEF\x8F\xBD"
+#endif
+
+#ifndef LV_SYMBOL_TIMER
+#define LV_SYMBOL_TIMER "\xEF\x80\x97"
+#endif
+
 /**********************
  *      TYPEDEFS
  **********************/


### PR DESCRIPTION
## Summary
- define temperature, speed, and timer symbols when not provided by LVGL to prevent compile errors

## Testing
- `pio run` *(fails: command not found, attempted installation blocked by proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c04801459083308b5839dd4c7bd955