### PR TITLE
Use unique LVGL font names for icons

### DIFF
--- a/src/fonts/mdi_28.c
+++ b/src/fonts/mdi_28.c
@@ -174,9 +174,9 @@ static lv_font_fmt_txt_dsc_t font_dsc = {
 
 /*Initialize a public general font descriptor*/
 #if LVGL_VERSION_MAJOR >= 8
-const lv_font_t mdi = {
+const lv_font_t mdi_28 = {
 #else
-lv_font_t mdi = {
+lv_font_t mdi_28 = {
 #endif
     .get_glyph_dsc = lv_font_get_glyph_dsc_fmt_txt,    /*Function pointer to get glyph's data*/
     .get_glyph_bitmap = lv_font_get_bitmap_fmt_txt,    /*Function pointer to get glyph's bitmap*/

--- a/src/fonts/mdi_icons_24.c
+++ b/src/fonts/mdi_icons_24.c
@@ -160,9 +160,9 @@ static lv_font_fmt_txt_dsc_t font_dsc = {
 
 /*Initialize a public general font descriptor*/
 #if LVGL_VERSION_MAJOR >= 8
-const lv_font_t mdi = {
+const lv_font_t mdi_icons_24 = {
 #else
-lv_font_t mdi = {
+lv_font_t mdi_icons_24 = {
 #endif
     .get_glyph_dsc = lv_font_get_glyph_dsc_fmt_txt,    /*Function pointer to get glyph's data*/
     .get_glyph_bitmap = lv_font_get_bitmap_fmt_txt,    /*Function pointer to get glyph's bitmap*/

--- a/src/fonts/mdi_icons_40.c
+++ b/src/fonts/mdi_icons_40.c
@@ -228,9 +228,9 @@ static lv_font_fmt_txt_dsc_t font_dsc = {
 
 /*Initialize a public general font descriptor*/
 #if LVGL_VERSION_MAJOR >= 8
-const lv_font_t mdi = {
+const lv_font_t mdi_icons_40 = {
 #else
-lv_font_t mdi = {
+lv_font_t mdi_icons_40 = {
 #endif
     .get_glyph_dsc = lv_font_get_glyph_dsc_fmt_txt,    /*Function pointer to get glyph's data*/
     .get_glyph_bitmap = lv_font_get_bitmap_fmt_txt,    /*Function pointer to get glyph's bitmap*/


### PR DESCRIPTION
## Summary
- ensure LVGL font descriptors have unique names to prevent link collisions

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0598675788330a1ec7d6c0d0da77d