### PR TITLE
Fix missing LVGL font in build configuration

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,6 +14,7 @@ set(app_sources
     ${DEMO_MAIN_DIR}/LVGL_UI/LVGL_Example.c
     ${DEMO_MAIN_DIR}/Wireless/Wireless.c
     ${DEMO_MAIN_DIR}/Buzzer/Buzzer.c
+    ${DEMO_MAIN_DIR}/fonts/mdi_icons_40.c
 )
 
 idf_component_register(
@@ -31,6 +32,7 @@ idf_component_register(
         ${DEMO_MAIN_DIR}/LVGL_UI
         ${DEMO_MAIN_DIR}/Wireless
         ${DEMO_MAIN_DIR}/Buzzer
+        ${DEMO_MAIN_DIR}/fonts
     REQUIRES
         lvgl__lvgl
         bt


### PR DESCRIPTION
## Summary
- Include `mdi_icons_40` font source in project build
- Add fonts directory to include paths

## Testing
- `pio run` *(fails: command not found)*
- `idf.py build` *(fails: command not found)*
- `python -m pip install platformio` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c05b520cfc8330926f3bf73ac79369