### PR TITLE
Remove deprecated static_bitmap from LVGL fonts

### DIFF
--- a/src/fonts/mdi_28.c
+++ b/src/fonts/mdi_28.c
@@ -189,7 +189,6 @@ lv_font_t mdi_28 = {
     .underline_position = 0,
     .underline_thickness = 0,
 #endif
-    .static_bitmap = 0,
     .dsc = &font_dsc,          /*The custom font data. Will be accessed by `get_glyph_bitmap/dsc` */
 #if LV_VERSION_CHECK(8, 2, 0) || LVGL_VERSION_MAJOR >= 9
     .fallback = NULL,

--- a/src/fonts/mdi_icons_24.c
+++ b/src/fonts/mdi_icons_24.c
@@ -175,7 +175,6 @@ lv_font_t mdi_icons_24 = {
     .underline_position = 0,
     .underline_thickness = 0,
 #endif
-    .static_bitmap = 0,
     .dsc = &font_dsc,          /*The custom font data. Will be accessed by `get_glyph_bitmap/dsc` */
 #if LV_VERSION_CHECK(8, 2, 0) || LVGL_VERSION_MAJOR >= 9
     .fallback = NULL,

--- a/src/fonts/mdi_icons_40.c
+++ b/src/fonts/mdi_icons_40.c
@@ -243,7 +243,6 @@ lv_font_t mdi_icons_40 = {
     .underline_position = 0,
     .underline_thickness = 0,
 #endif
-    .static_bitmap = 0,
     .dsc = &font_dsc,          /*The custom font data. Will be accessed by `get_glyph_bitmap/dsc` */
 #if LV_VERSION_CHECK(8, 2, 0) || LVGL_VERSION_MAJOR >= 9
     .fallback = NULL,


### PR DESCRIPTION
## Summary
- drop obsolete `.static_bitmap` field from generated font definitions for LVGL 8+

## Testing
- `pio run` *(fails: command not found; pip installation blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c06adf8f448330aa356c2ef95316e9