### PR TITLE
fix: remove deprecated static_bitmap field

### DIFF
--- a/src/fonts/mdi_icons_40.c
+++ b/src/fonts/mdi_icons_40.c
@@ -243,7 +243,6 @@ lv_font_t mdi_icons_40 = {
     .underline_position = 0,
     .underline_thickness = 0,
 #endif
-    .static_bitmap = 0,
     .dsc = &font_dsc,          /*The custom font data. Will be accessed by `get_glyph_bitmap/dsc` */
 #if LV_VERSION_CHECK(8, 2, 0) || LVGL_VERSION_MAJOR >= 9
     .fallback = NULL,


### PR DESCRIPTION
## Summary
- remove deprecated static_bitmap field from mdi_icons_40 font so it builds with LVGL v8+

## Testing
- `pio run -e esp32-s3-devkitc-1` *(fails: command not found)*
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement platformio)*

------
https://chatgpt.com/codex/tasks/task_e_68c0850773908330a6f0a389578d7837